### PR TITLE
Initial version - Copies files from your config repo directly to /etc

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build Nix targets
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v3
+      - name: Run nix flake checks
+        run: nix flake check --all-systems -L

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # nix-copy-etc
-Automatically copy files directly from ./etc in your config repo into your nix install
+Automatically copy files directly from ./etc in your config repo into /etc/ in your nix install
+
+## Summary
+
+Nix provides the [environment.etc](https://search.nixos.org/options?channel=unstable&show=environment.etc) configuration option as a way to create files in the `/etc` directory of the configured Nix install. In many cases, however, you simply want to copy over a file and don't need to configure advanced options for it. In this scenario it's simpler to have the file directly in your configuration repo and have it copied over wholesale. This is where `nix-copy-etc` comes in.
+
+## Installation and Usage
+
+To enable this module, add it to your flake configuration:
+
+```
+{
+  inputs {
+    copy-to-etc.url = "github:efirestone/nix-copy-to-etc/0.1.0";
+    nixpkgs.url = "nixpkgs/nixos-24.11";
+  };
+
+  outputs = { self, nixpkgs, copy-to-etc }: let
+    system = "x86_64-linux";
+  in {
+    nixosConfigurations.myHost = nixpkgs.lib.nixosSystem {
+      system = system;
+      modules = [
+        ./configuration.nix
+        copy-to-etc.nixosModules.copy-to-etc
+      ];
+    };
+  };
+}
+```
+
+and then enable the module:
+
+```
+services.copy-to-etc.enable = true;
+```
+
+By default, `nix-copy-etc` will look for files in the `./etc` directory of your configuration repo, but you can configure one or more different directories instead if you want:
+
+```
+services.copy-to-etc.sourceDirs = [ ./tests/etc1 ./tests/etc2 ];
+```
+
+## Caveats
+
+### Nix Store
+
+Under the covers this flake is using `environment.etc`, which copies the files into the Nix store, then symlinks them into `/etc`. This means that your files will be unlinked if you remove them from your config (and deploy that config), but they will still be stored in the Nix store until you garbage collect it.
+
+### File Ownership and Permissions
+
+The current version does not attempt to set the permissions or ownership of the files in any way. The defaults provided by `environment.etc` are used.
+
+### Overlapping Files
+
+The current version also does not detect the case where two local directories contain files that will end up at the same path in `/etc`. For example, if you had `./etc1/config.yaml` and `./etc2/config.yaml` and you configured `sourceDirs` to be `[ ./etc1 ./etc2 ]`. In this case the one processed later (the `etc2` one in this case) would be used, but no warning is issued.
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737507713,
+        "narHash": "sha256-w5xL1oUVRZRC6mZ9CcuhfLn3b1vB5SXEMyzBQH8btvc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0d6514cc638f30997676f5be71317c7dc917ef0f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.11-small",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A nix service that copies all files from ./etc (or another directory) in your config repo to /etc in your Nix system.";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-24.11-small";
+
+  outputs = { self, nixpkgs }:
+  let
+    forEachSystem = nixpkgs.lib.genAttrs [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+
+    overlayList = [ self.overlays.default ];
+  in {
+    # A Nixpkgs overlay that provides a 'copy-to-etc' package.
+    overlays.default = final: prev: { copy-to-etc = final.callPackage ./package.nix {}; };
+
+    packages = forEachSystem (system: {
+      copy-to-etc = nixpkgs.legacyPackages.${system}.callPackage ./package.nix {};
+      default = self.packages.${system}.copy-to-etc;
+    });
+
+    nixosModules = import ./nixos-modules { overlays = overlayList; };
+
+    checks = forEachSystem (system: {
+      # To run the tests: nix flake check --all-systems
+      # You may also want the -L and --verbose flags for additional debugging.
+      multipleSourceDirTest = nixpkgs.legacyPackages.${system}.testers.runNixOSTest {
+        name = "multipleSourceDirTest";
+        nodes.machine = {
+          imports = [ self.outputs.nixosModules.copy-to-etc ];
+
+          # enable our custom module
+          services.copy-to-etc.enable = true;
+          services.copy-to-etc.sourceDirs = [ ./tests/etc1 ./tests/etc2 ];
+        };
+        testScript = ''
+          machine.wait_for_unit("multi-user.target")
+          
+          assert machine.execute("cat /etc/config1.txt")[1] == "Configuration 1"
+          assert machine.execute("cat /etc/nested/config2.txt")[1] == "Configuration 2"
+        '';
+      };
+    });
+  };
+}

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -1,0 +1,13 @@
+{ overlays }:
+
+{
+  copy-to-etc = import ./service.nix;
+
+  overlayNixpkgsForThisInstance =
+    { pkgs, ... }:
+    {
+      nixpkgs = {
+        inherit overlays;
+      };
+    };
+}

--- a/nixos-modules/service.nix
+++ b/nixos-modules/service.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  pkgs,
+  lib ? pkgs.lib,
+  ...
+}:
+
+with lib;
+
+# Copy everything from the sourceDirs directories into the /etc/ directory on the remote Nix machine.
+let
+  cfg = config.services.copy-to-etc;
+  sourceDirs = cfg.sourceDirs;
+
+  # Recursive function to collect all files in a directory
+  collectFiles = path: builtins.concatLists (map (name:
+    let
+      subPath = "${path}/${name}";
+    in if builtins.readFileType subPath == "directory" then
+      collectFiles subPath
+    else
+      [ subPath ]
+  ) (builtins.attrNames (builtins.readDir path)));
+
+  sourceDirsThatExist = builtins.filter (dir: builtins.pathExists dir) sourceDirs;
+
+  # Create a list of entries for all files in all source dirs, where each entry
+  # contains the local file path (value) and the path within the Nix install (name).
+  allFiles = builtins.concatLists (map (sourceDir:
+    map (file: {
+      name = builtins.unsafeDiscardStringContext (builtins.substring (builtins.stringLength sourceDir + 1) (builtins.stringLength file) file); # Strip sourceDir prefix
+      value = { source = file; };
+    }) (collectFiles sourceDir)
+  ) sourceDirsThatExist);
+
+  # Convert to environment.etc-compatible structure
+  etcFiles = builtins.listToAttrs allFiles;
+in {
+  options = {
+    services.copy-to-etc = rec {
+      enable = mkEnableOption "Copy files directly from your config directory to /etc.";
+      sourceDirs = lib.mkOption {
+        type = types.listOf types.path;
+        default = [ ./etc ];
+        description = ''
+          The directories in the configuration repo which contain files to copy into /etc.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc = etcFiles;
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,8 @@
+{ stdenv, system }:
+
+derivation {
+  name = "copy-to-etc";
+  builder = "/bin/sh";
+  args = [ "-c" "echo hello world > $out" ];
+  inherit system;
+}

--- a/tests/etc1/config1.txt
+++ b/tests/etc1/config1.txt
@@ -1,0 +1,1 @@
+Configuration 1

--- a/tests/etc2/nested/config2.txt
+++ b/tests/etc2/nested/config2.txt
@@ -1,0 +1,1 @@
+Configuration 2


### PR DESCRIPTION
This provides an initial implementation of a flake that copies configuration files directly from your `./etc` directory (configurable) in your configuration repo to the `/etc` directory in your Nix install.

This initial version supports copying from multiple configuration directories in your repo, and also includes a test to verify that behavior.