### PR TITLE
Force specifying the source directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To enable this module, add it to your flake configuration:
 ```
 {
   inputs {
-    copy-to-etc.url = "github:efirestone/nix-copy-to-etc/0.1.0";
+    copy-to-etc.url = "github:efirestone/nix-copy-to-etc/0.1.1";
     nixpkgs.url = "nixpkgs/nixos-24.11";
   };
 
@@ -36,10 +36,10 @@ and then enable the module:
 services.copy-to-etc.enable = true;
 ```
 
-By default, `copy-to-etc` will look for files in the `./etc` directory of your configuration repo, but you can configure one or more different directories instead if you want:
+You configure one or more different directories using the `sourceDirs` property. At least one directory must be specified.
 
 ```
-services.copy-to-etc.sourceDirs = [ ./tests/etc1 ./tests/etc2 ];
+services.copy-to-etc.sourceDirs = [ ./etc ./nfs/etc ];
 ```
 
 ## Caveats

--- a/nixos-modules/service.nix
+++ b/nixos-modules/service.nix
@@ -41,7 +41,7 @@ in {
       enable = mkEnableOption "Copy files directly from your config directory to /etc.";
       sourceDirs = lib.mkOption {
         type = types.listOf types.path;
-        default = [ ./etc ];
+        default = [];
         description = ''
           The directories in the configuration repo which contain files to copy into /etc.
         '';
@@ -50,6 +50,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.etc = etcFiles;
+    environment.etc = lib.throwIf (sourceDirs == [])
+      "copy-to-etc.sourceDirs must contain at least one entry." etcFiles;
   };
 }


### PR DESCRIPTION
We can't default to `./etc` in the flake, because that evaluates to being relative to the copy-to-etc flake itself, not the flake in the configuration repo where the files to be copied actually live. Instead, require that the config repo specifies the directories to copy from.